### PR TITLE
Set form text to "Steam Auto Shutdown"

### DIFF
--- a/Steam Auto Shutdown/Steam Auto Shutdown/MainForm.Designer.cs
+++ b/Steam Auto Shutdown/Steam Auto Shutdown/MainForm.Designer.cs
@@ -455,7 +455,7 @@ namespace Steam_Auto_Shutdown
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "MainForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Form1";
+            this.Text = "Steam Auto Shutdown";
             this.MouseDown += new System.Windows.Forms.MouseEventHandler(this.MainForm_MouseDown);
             this.MouseMove += new System.Windows.Forms.MouseEventHandler(this.MainForm_MouseMove);
             this.MouseUp += new System.Windows.Forms.MouseEventHandler(this.MainForm_MouseUp);


### PR DESCRIPTION
Set form text so "Steam Auto Shutdown" is shown in windows taskbar instead of "Form1"

Old:
![image](https://user-images.githubusercontent.com/17119621/180339574-b17b99d1-f95c-4001-a290-43bf826e52ea.png)

New:
![image](https://user-images.githubusercontent.com/17119621/180339495-1751dd63-e222-48da-8242-e3f27a151d23.png)
